### PR TITLE
Add Meta Box plugin

### DIFF
--- a/src/frameworks/meta-box.php
+++ b/src/frameworks/meta-box.php
@@ -2,7 +2,7 @@
 $framework = array(
     'name'           => 'Meta Box',
     'full_name'      => 'Meta Box',
-    'description'    => 'A framework for developers to handle custom meta boxes and custom fields.',
+    'description'    => 'A custom meta boxes and custom fields toolset.',
     'github_repo'    => 'rilwis/meta-box',
     'wp_slug'        => 'meta-box',
     'homepage'       => 'https://metabox.io',

--- a/src/frameworks/meta-box.php
+++ b/src/frameworks/meta-box.php
@@ -1,0 +1,15 @@
+<?php
+$framework = array(
+    'name'           => 'Meta Box',
+    'full_name'      => 'Meta Box',
+    'description'    => 'A framework for developers to handle custom meta boxes and custom fields.',
+    'github_repo'    => 'rilwis/meta-box',
+    'wp_slug'        => 'meta-box',
+    'homepage'       => 'https://metabox.io',
+    'is_for_plugins' => true,
+    'is_for_themes'  => true,
+    'thumbprint'     => array(
+        'file'  => 'meta-box.php',
+        'token' => 'class RW_Meta_Box',
+    ),
+);


### PR DESCRIPTION
This PR adds the Meta Box plugin, a framework for developers to handle custom meta boxes and custom fields in WordPress.
